### PR TITLE
fix: tag name should not be bumped if bump is disabled in options

### DIFF
--- a/tasks/grunt-release.js
+++ b/tasks/grunt-release.js
@@ -44,7 +44,10 @@ module.exports = function(grunt){
 
     function setup(file, type){
       var pkg = grunt.file.readJSON(file);
-      var newVersion = pkg.version = semver.inc(pkg.version, type || 'patch');
+      var newVersion = pkg.version;
+      if (options.bump) {
+        newVersion = semver.inc(pkg.version, type || 'patch');
+      }
       return {file: file, pkg: pkg, newVersion: newVersion};
     }
 


### PR DESCRIPTION
Currently, I bump the version of the app with another Grunt task, then generate the changelog with https://github.com/btford/grunt-conventional-changelog, then I run this task to commit, tag, push, and publish.

Unfortunately, `bump: false` in the options just prevents this task from saving the bumped version, but it still uses the updated version to tag and commit.

This patch fixes the issue so that if `bump` is set to `false`, grunt uses the old version number for the commit and tag.
