### PR TITLE
Bump version in multiple files (with a multitask)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,8 @@ Done, without errors.
 You can disable any of the steps if you want, by adding this to your Gruntfile:
 
 ```js
-  release: {
+  'release-publish': {
     options: {
-      bump: false, //default: true
       file: 'component.json', //default: package.json
       add: false, //default: true
       commit: false, //default: true
@@ -128,6 +127,15 @@ You can disable any of the steps if you want, by adding this to your Gruntfile:
   }
 ```
 For node libs, leave `file` option blank. For bower components, set it to `component.json` or whatever you've set your bower config file to be.
+
+To bump the version numbers in your node or bower libs, add this to your Gruntfile:
+
+```js
+  'release-bump': {
+    npm: 'package.json',
+    bower: 'bower.json'
+  }
+```
 
 ## Credits
 Inspired by Vojta Jina's [grunt-bump](https://github.com/vojtajina/grunt-bump).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-release",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Release a new version of your Node-based project",
   "main": "Gruntfile.js",
   "scripts": {


### PR DESCRIPTION
Another attempt at bumping the versions in both `package.json` and `bower.json`. Unlike the previous attempt (#34) this one uses a Grunt multitask to loop through the files. @geddski thanks for encouraging me to learn the right way to do things in Grunt.

**This PR is not ready to merge yet.** I am opening it so we can discuss the multitask approach. Here's how it works
- Rather than registering a single "release" task it registers the tasks "release-publish," "release," and the multitask "release-bump"
- The release task does nothing except require the other two

So the user's Gruntfile configuration might look like this

``` js
'release-bump': {
  npm: 'package.json',
  bower: 'bower.json'
},
'release-publish': {
  options: {
    push: false,
    pushTags: false,
    npm: false
  }
}
```

What's broken:
- If you don't want to bump any files you remove the "release-bump" task, but that makes `grunt release` fail saying

```
  Running "release-bump" task
  >> No "release-bump" targets found.
  Warning: Task "release-bump" failed. Use --force to continue.
```
- The type (e.g. major, minor, patch, or prerelease) does not get passed to release-bump.
- Not sure if the hyphenation is the normal way to namespace things for Grunt libraries, and it forces the user to quote the tasks.
