### PR TITLE
Adding ability to npm shrinkwrap as part of release

### DIFF
--- a/tasks/grunt-release.js
+++ b/tasks/grunt-release.js
@@ -11,6 +11,11 @@ var semver = require('semver');
 
 module.exports = function(grunt){
   grunt.registerTask('release', 'bump version, git tag, git push, npm publish', function(type){
+
+    if(!type || (type !== 'patch' && type !== 'minor' && type !== 'major' && type !== 'prerelease')) {
+      grunt.fatal('Type of release must be specific as: patch, minor, major, prerelease')
+    }
+
     //defaults
     var options = this.options({
       bump: true,


### PR DESCRIPTION
I assume you won't take this pull request as is, but I'd love to get the ability to [npm shrinkwrap](https://npmjs.org/doc/shrinkwrap.html) into this package.

Since I needed to put a few commits for my idea use, the only commit I'm reference in this request is:
https://github.com/whentomanage/grunt-release/commit/0255ccf376bbfced9a861df148f82bb4cc0d4821

With this addition, the grunt-release is perfect for my workflow. What can I tweak (besides adding tests), for you to accept this?

Thanks for the repo! :+1: 
