### PR TITLE
Capitalize Release and Version in commit and tag messages

### DIFF
--- a/tasks/grunt-release.js
+++ b/tasks/grunt-release.js
@@ -24,8 +24,8 @@ module.exports = function(grunt){
     });
 
     var tagName = grunt.config.getRaw('release.options.tagName') || '<%= version %>';
-    var commitMessage = grunt.config.getRaw('release.options.commitMessage') || 'release <%= version %>';
-    var tagMessage = grunt.config.getRaw('release.options.tagMessage') || 'version <%= version %>';
+    var commitMessage = grunt.config.getRaw('release.options.commitMessage') || 'Release <%= version %>';
+    var tagMessage = grunt.config.getRaw('release.options.tagMessage') || 'Version <%= version %>';
 
     var config = setup(options.file, type);
     var templateOptions = {


### PR DESCRIPTION
It seems pretty standard practice to capitalize commit messages and tag messages. When I make edits to a file directly on GitHub, the message is `Updated file`. I would like to have my auto-generated release messages be capitalized like the rest of my commits.

Thanks for making this great plugin by the way, this is the beauty of grunt automating stuff like this!
