### PR TITLE
Copy package file to published directory.

### DIFF
--- a/tasks/grunt-release.js
+++ b/tasks/grunt-release.js
@@ -8,6 +8,7 @@
 
 var shell = require('shelljs');
 var semver = require('semver');
+var path = require('path');
 
 module.exports = function(grunt){
   grunt.registerTask('release', 'bump version, git tag, git push, npm publish', function(type){
@@ -82,7 +83,10 @@ module.exports = function(grunt){
         cmd += ' --tag ' + npmtag;
         msg += ' with a tag of "' + npmtag + '"';
       }
-      if (options.folder){ cmd += ' ' + options.folder }
+      if (options.folder){
+        cmd += ' ' + options.folder;
+        grunt.file.copy(config.file, path.join(options.folder, path.basename(config.file)));
+      }
       run(cmd, msg);
     }
 


### PR DESCRIPTION
Addresses the comment I made here: https://github.com/geddski/grunt-release/issues/6#issuecomment-26016636

In summary:

If you use the "folder" option, then you're publishing a different directory than the one that contains your package.json file. That means that the published folder has either a stale version number or no package.json file at all. This patch simply copies the updated file over prior to publishing.
