### PR TITLE
User-Agent is required by Github's API.

### DIFF
--- a/tasks/grunt-release.js
+++ b/tasks/grunt-release.js
@@ -123,6 +123,7 @@ module.exports = function(grunt){
         .post('https://api.github.com/repos/' + options.github.repo + '/releases')
         .auth(process.env[options.github.usernameVar], process.env[options.github.passwordVar])
         .set('Accept', 'application/vnd.github.manifold-preview')
+        .set('User-Agent', 'grunt-release')
         .send({"tag_name": tagName, "name": tagMessage})
         .end(function(res){
           if (res.statusCode === 201){


### PR DESCRIPTION
I've used grunt-release as value; this is something Github uses in case of problems, as documented here http://developer.github.com/v3/#user-agent-required
