### PR TITLE
Insert missing commas into example options

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,10 @@ The following are all the release steps, you can disable any you need to:
       pushTags: false, //default: true
       npm: false, //default: true
       npmtag: true, //default: no tag
-      folder: 'folder/to/publish/to/npm' //default project root
+      folder: 'folder/to/publish/to/npm', //default project root
       tagName: 'some-tag-<%= version %>', //default: '<%= version %>'
       commitMessage: 'check out my release <%= version %>', //default: 'release <%= version %>'
-      tagMessage: 'tagging version <%= version %>' //default: 'Version <%= version %>',
+      tagMessage: 'tagging version <%= version %>', //default: 'Version <%= version %>',
       github: { 
         repo: 'geddski/grunt-release', //put your user/repo here
         usernameVar: 'GITHUB_USERNAME', //ENVIRONMENT VARIABLE that contains Github username 


### PR DESCRIPTION
Discovered, ironically, by me trying to `js2coffee` them.
