### PR TITLE
Default to annotated tags rather than lightweight

### DIFF
--- a/tasks/grunt-release.js
+++ b/tasks/grunt-release.js
@@ -109,7 +109,7 @@ module.exports = function(grunt){
     }
 
     function tag(){
-      return run('git tag ' + tagName + ' -m "'+ tagMessage +'"', 'created new git tag: ' + tagName);
+      return run('git tag --annotate ' + tagName + ' -m "'+ tagMessage +'"', 'created new git tag: ' + tagName);
     }
 
     function push(){

--- a/tasks/grunt-release.js
+++ b/tasks/grunt-release.js
@@ -76,20 +76,16 @@ module.exports = function(grunt){
 
     function getTagTypeArg(){
       var type = grunt.option('tagType') || options.tagType;
-      arg = '';
-      switch(type)
-      {
+      switch(type) {
         case 'annotated':
-          arg = '--annotate ';
+          return arg = '--annotate ';
         case 'signed':
-          arg = '--sign ';
+          return '--sign ';
         case 'lightweight':
-          arg = '';
+          return '';
         default:
-          throw 'Unrecognized tagType: ' + type;
-
+          throw grunt.util.error('Unrecognized tagType: "' + type + '".');
       }
-     return arg;
     }
 
     function ifEnabled(option, fn){

--- a/tasks/grunt-release.js
+++ b/tasks/grunt-release.js
@@ -32,6 +32,7 @@ module.exports = function(grunt){
         version: config.newVersion
       }
     };
+    var tagType = grunt.template.process(grunt.config.getRaw('release.options.tagType') || 'annotated', templateOptions);
     var tagName = grunt.template.process(grunt.config.getRaw('release.options.tagName') || '<%= version %>', templateOptions);
     var commitMessage = grunt.template.process(grunt.config.getRaw('release.options.commitMessage') || 'release <%= version %>', templateOptions);
     var tagMessage = grunt.template.process(grunt.config.getRaw('release.options.tagMessage') || 'version <%= version %>', templateOptions);
@@ -73,6 +74,24 @@ module.exports = function(grunt){
       return tag;
     }
 
+    function getTagTypeArg(){
+      var type = grunt.option('tagType') || options.tagType;
+      arg = '';
+      switch(type)
+      {
+        case 'annotated':
+          arg = '--annotate ';
+        case 'signed':
+          arg = '--sign ';
+        case 'lightweight':
+          arg = '';
+        default:
+          throw 'Unrecognized tagType: ' + type;
+
+      }
+     return arg;
+    }
+
     function ifEnabled(option, fn){
       if (options[option]) return fn;
     }
@@ -109,7 +128,7 @@ module.exports = function(grunt){
     }
 
     function tag(){
-      return run('git tag --annotate ' + tagName + ' -m "'+ tagMessage +'"', 'created new git tag: ' + tagName);
+      return run('git tag ' + getTagTypeArg() + tagName + ' -m "'+ tagMessage +'"', 'created new ' + tagType + ' git tag: ' + tagName);
     }
 
     function push(){

--- a/tasks/grunt-release.js
+++ b/tasks/grunt-release.js
@@ -79,8 +79,6 @@ module.exports = function(grunt){
       switch(type) {
         case 'annotated':
           return arg = '--annotate ';
-        case 'signed':
-          return '--sign ';
         case 'lightweight':
           return '';
         default:

--- a/tasks/grunt-release.js
+++ b/tasks/grunt-release.js
@@ -13,7 +13,7 @@ var Q = require('q');
 
 module.exports = function(grunt){
   grunt.registerTask('release', 'bump version, git tag, git push, npm publish', function(type){
-    
+
     //defaults
     var options = this.options({
       bump: true,
@@ -75,14 +75,13 @@ module.exports = function(grunt){
     }
 
     function getTagTypeArg(){
-      var type = grunt.option('tagType') || options.tagType;
-      switch(type) {
+      switch(tagType) {
         case 'annotated':
-          return arg = '--annotate ';
+          return '--annotate ';
         case 'lightweight':
           return '';
         default:
-          throw grunt.util.error('Unrecognized tagType: "' + type + '".');
+          throw grunt.util.error('Unrecognized tagType: "' + tagType + '".');
       }
     }
 
@@ -101,7 +100,7 @@ module.exports = function(grunt){
       else {
         var success = shell.exec(cmd, {silent:true}).code === 0;
 
-        if (success){ 
+        if (success){
           grunt.log.ok(msg || cmd);
           deferred.resolve();
         }
@@ -137,7 +136,7 @@ module.exports = function(grunt){
       var cmd = 'npm publish';
       var msg = 'published version '+ config.newVersion +' to npm';
       var npmtag = getNpmTag();
-      if (npmtag){ 
+      if (npmtag){
         cmd += ' --tag ' + npmtag;
         msg += ' with a tag of "' + npmtag + '"';
       }
@@ -156,7 +155,7 @@ module.exports = function(grunt){
 
     function githubRelease(){
       var deferred = Q.defer();
-      if (nowrite){ 
+      if (nowrite){
         success();
         return;
       }
@@ -170,7 +169,7 @@ module.exports = function(grunt){
         .end(function(res){
           if (res.statusCode === 201){
             success();
-          } 
+          }
           else {
             deferred.reject('Error creating github release. Response: ' + res.text);
           }


### PR DESCRIPTION
I haven't been in the habit of doing this myself, but just learned that annotated tags are the best-practice:
http://git-scm.com/book/en/Git-Basics-Tagging#Creating-Tags

Worth switching the default for? Would seem that lightweight tags would be a good override