### PR TITLE
Add optional step to create pgp-signed git commits

### DIFF
--- a/tasks/grunt-release.js
+++ b/tasks/grunt-release.js
@@ -81,6 +81,8 @@ module.exports = function(grunt){
           return arg = '--annotate ';
         case 'lightweight':
           return '';
+        case 'signed':
+          return '--sign ';
         default:
           throw grunt.util.error('Unrecognized tagType: "' + type + '".');
       }


### PR DESCRIPTION
New to this myself, but seems it would be a nice addition :)

Ref: https://github.com/gittip/roobot/issues/4
### To Do
- [x] add `signed` tagType to switch
- [ ] check for `gpg` command and throw helpful output if unavailable
- [ ] check for `git config user.signingkey` config value, with helpful output
- [ ] pass any remaining git failures forward
