### PR TITLE
Support bumping version in multiple config files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,8 +1,10 @@
 module.exports = function(grunt) {
   grunt.initConfig({
-    
+
     clean: {
-      test: 'test/fixtures/_component.json'
+      test: [
+        'test/fixtures/_*.json'
+      ]
     },
     nodeunit: {
       tests: 'test/release_test.js'
@@ -27,8 +29,22 @@ module.exports = function(grunt) {
     },
     setup: {
       test: {
-        src: 'test/fixtures/component.json',
-        dest: 'test/fixtures/_component.json'
+        files: [
+          {
+            src: 'test/fixtures/component.json',
+            dest: 'test/fixtures/_component.json'
+          },
+
+          {
+            src: 'test/fixtures/bower.json',
+            dest: 'test/fixtures/_bower.json'
+          },
+
+          {
+            src: 'test/fixtures/component2.json',
+            dest: 'test/fixtures/_component2.json'
+          }
+        ]
       }
     }
   });
@@ -40,7 +56,8 @@ module.exports = function(grunt) {
   grunt.registerTask('test', [
     'clean',
     'setup',
-    'release',
+    'test-release1',
+    'test-release2',
     'nodeunit',
     'clean'
   ]);
@@ -49,7 +66,7 @@ module.exports = function(grunt) {
     this.files.forEach(function(f){
       grunt.file.copy(f.src, f.dest);
     });
-    grunt.config.set('release.options.file', 'test/fixtures/_component.json');
+
     grunt.config.set('release.options.add', false);
     grunt.config.set('release.options.commit', false);
     grunt.config.set('release.options.tag', false);
@@ -57,5 +74,20 @@ module.exports = function(grunt) {
     grunt.config.set('release.options.pushTags', false);
     grunt.config.set('release.options.npm', false);
     grunt.config.set('release.options.github', false);
+  });
+
+  grunt.registerTask('test-release1', 'Test release for multiple config files', function () {
+    grunt.config.set('release.options.file', null);
+    grunt.config.set('release.options.files', [
+      'test/fixtures/_component.json',
+      'test/fixtures/_bower.json'
+    ]);
+    grunt.task.run('release');
+  });
+
+  grunt.registerTask('test-release2', 'Test release for single config file', function() {
+    grunt.config.set('release.options.files', []);
+    grunt.config.set('release.options.file', 'test/fixtures/_component2.json');
+    grunt.task.run('release');
   });
 };

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # grunt-release
-[Grunt](http://gruntjs.com) plugin for automating all the release steps of your node lib or bower component, with optional publishing to npm.  
+[Grunt](http://gruntjs.com) plugin for automating all the release steps of your node lib or bower component, with optional publishing to npm.
 
 ## Repetition Killed the Cat
 Releasing a new version of your killer Node/Bower/Component/JS lib looks something like this:
@@ -7,7 +7,7 @@ Releasing a new version of your killer Node/Bower/Component/JS lib looks somethi
 1. bump the version in your `package.json` file.
 2. stage the package.json file's change.
 3. commit that change with a message like "release 0.6.22".
-4. create a new git tag for the release. 
+4. create a new git tag for the release.
 5. push the changes out to github.
 6. also push the new tag out to github.
 7. create a .zip release on github.
@@ -65,7 +65,7 @@ If you want to add an alphanumeric identifier, you will need to add it by hand.
 Example: add `-alpha.0` to get something like `1.0.0-alpha.0`. Calling `grunt release:prerelease` will just update the last number to `1.0.0-alpha.1`.
 
 **Releasing Unstable/Beta Versions**
-Sometimes it is useful to publish an 'unstable' or 'beta' version to `npm`, while leaving your last stable release as the default that gets installed on an `npm install`. 
+Sometimes it is useful to publish an 'unstable' or 'beta' version to `npm`, while leaving your last stable release as the default that gets installed on an `npm install`.
 `npm` accomplishes this using the `--tag myUnstableVersion` flag. You can enable this flag in grunt-release either by setting the `npmtag` option:
 
 ```js
@@ -114,7 +114,8 @@ The following are all the release steps, you can disable any you need to:
   release: {
     options: {
       bump: false, //default: true
-      file: 'component.json', //default: package.json
+      file: 'component.json', //deprecated; default: 'package.json'
+      files: ['component.json', 'bower.json'], //overrides file property
       add: false, //default: true
       commit: false, //default: true
       tag: false, //default: true
@@ -126,9 +127,9 @@ The following are all the release steps, you can disable any you need to:
       tagName: 'some-tag-<%= version %>', //default: '<%= version %>'
       commitMessage: 'check out my release <%= version %>', //default: 'release <%= version %>'
       tagMessage: 'tagging version <%= version %>', //default: 'Version <%= version %>',
-      github: { 
+      github: {
         repo: 'geddski/grunt-release', //put your user/repo here
-        usernameVar: 'GITHUB_USERNAME', //ENVIRONMENT VARIABLE that contains Github username 
+        usernameVar: 'GITHUB_USERNAME', //ENVIRONMENT VARIABLE that contains Github username
         passwordVar: 'GITHUB_PASSWORD' //ENVIRONMENT VARIABLE that contains Github password
       }
     }
@@ -140,7 +141,9 @@ The following are all the release steps, you can disable any you need to:
 2. The [Github Releases API](http://developer.github.com/v3/repos/releases/) is still unstable and may change in the future.
 3. You can use an [access token](https://help.github.com/articles/creating-an-access-token-for-command-line-use) if you'd rather.
 
-For node libs, leave `file` option blank as it will default to `package.json`. For Bower components, set it to `bower.json`.
+By default, grunt-release will attempt to bump the `version` property in `package.json`. If you have multiple files, use a `files` property containing an array of paths for JSON files to modify. The first file in this array is considered the "primary", and is used as the source for the `version` property to bump; the `version` property in the other files is synchronised to this one.
+
+The `file` property is maintained for backwards-compatibility, but will be ignored if `files` is set.
 
 ## License
 MIT

--- a/test/expected/bower.json
+++ b/test/expected/bower.json
@@ -1,0 +1,20 @@
+{
+  "name": "test",
+  "main": "test.js",
+  "version": "0.0.13",
+  "description": "test fixture",
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "examples",
+    "Gruntfile.js",
+    "package.json",
+    "README.md"
+  ],
+  "devDependencies": {
+    "requirejs": "~2.1.11"
+  }
+}

--- a/test/expected/component2.json
+++ b/test/expected/component2.json
@@ -1,0 +1,4 @@
+{
+  "name": "grunt-release-test",
+  "version": "0.0.7"
+}

--- a/test/fixtures/bower.json
+++ b/test/fixtures/bower.json
@@ -1,0 +1,20 @@
+{
+  "name": "test",
+  "main": "test.js",
+  "version": "0.0.1",
+  "description": "test fixture",
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "examples",
+    "Gruntfile.js",
+    "package.json",
+    "README.md"
+  ],
+  "devDependencies": {
+    "requirejs": "~2.1.11"
+  }
+}

--- a/test/fixtures/component2.json
+++ b/test/fixtures/component2.json
@@ -1,0 +1,4 @@
+{
+  "name": "grunt-release-test",
+  "version": "0.0.6"
+}

--- a/test/release_test.js
+++ b/test/release_test.js
@@ -1,12 +1,26 @@
 var grunt = require('grunt');
 
 exports.release = {
-  bump: function(test){
-    test.expect(1);
+  bumpMultipleFiles: function(test){
+    test.expect(2);
 
     var actual = grunt.file.readJSON('test/fixtures/_component.json');
     var expected = grunt.file.readJSON('test/expected/component.json');
     test.equal(actual.version, expected.version, 'should set version 0.0.13');
+
+    actual = grunt.file.readJSON('test/fixtures/_bower.json');
+    expected = grunt.file.readJSON('test/expected/bower.json');
+    test.equal(actual.version, expected.version, 'should sync bower version to 0.0.13');
+
+    test.done();
+  },
+
+  bumpOneFile: function(test){
+    test.expect(1);
+
+    var actual = grunt.file.readJSON('test/fixtures/_component2.json');
+    var expected = grunt.file.readJSON('test/expected/component2.json');
+    test.equal(actual.version, expected.version, 'should set version 0.0.7');
 
     test.done();
   }


### PR DESCRIPTION
Add a new "files" property which can be set to an array of JSON files. Each should contain a "version" property. On release, the bump() function now updates the "version" property in each file.

The "file" option is maintained for backwards-compatibility, but is ignored if "files" is set.

Fixes #56