### PR TITLE
Bump version in npm-shrinkwrap.json if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The following are all the release steps, you can disable any you need to:
   release: {
     options: {
       bump: false, //default: true
+      bumpShrinkwrap: true, //default: false
       file: 'component.json', //default: package.json
       add: false, //default: true
       commit: false, //default: true


### PR DESCRIPTION
A good practice for npm-shrinkwrap is to visually confirm the changes in the file before committing and generating a release via `grunt release`. But now the package.json version and npm-shrinkwrap.json versions are out of sync, since only the former is bumped.

Someone else suggested _generating_ the shrinkwrap as part of grunt-release (#39), but I think simply incrementing would be a better addition.

Thoughts?
