### PR TITLE
Fix `Cannot read property 'options' of undefined`

### DIFF
--- a/tasks/grunt-release.js
+++ b/tasks/grunt-release.js
@@ -46,7 +46,7 @@ module.exports = function(grunt){
       pushTags: true,
       npm : true,
       remote: 'origin'
-    }, grunt.config(this.name).options);
+    }, (grunt.config(this.name) || {}).options);
 
     var config = setup(options.file, type);
     var templateOptions = {


### PR DESCRIPTION
When no options for release task:
```
$ grunt release --stack
Running "release:patch" (release) task
Warning: Cannot read property 'options' of undefined Use --force to continue.
TypeError: Cannot read property 'options' of undefined
  at Object.<anonymous> ([...]/node_modules/grunt-release/tasks/grunt-release.js:51:31)
  at Object.thisTask.fn ([...]/node_modules/grunt/lib/grunt/task.js:82:16)
  at Object.<anonymous> ([...]/node_modules/grunt/lib/util/task.js:301:30)
  at Task.runTaskFn ([...]/node_modules/grunt/lib/util/task.js:251:24)
  at Task.<anonymous> ([...]/node_modules/grunt/lib/util/task.js:300:12)
  at Task.start ([...]/node_modules/grunt/lib/util/task.js:309:5)
  at Object.grunt.tasks ([...]/node_modules/grunt/lib/grunt.js:164:8)
  at Object.module.exports [as cli] ([...]/node_modules/grunt/lib/grunt/cli.js:38:9)
  at Object.<anonymous> (/usr/local/lib/node_modules/grunt-cli/bin/grunt:45:20)
  at Module._compile (module.js:460:26)
  at Object.Module._extensions..js (module.js:478:10)
  at Module.load (module.js:355:32)
  at Function.Module._load (module.js:310:12)
  at Function.Module.runMain (module.js:501:10)
  at startup (node.js:124:16)
  at node.js:842:3
```

Task config can be undefined. Since unknown version, grunt.config result `undefined` if no options are found.
