### PR TITLE
Prerelease ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ grunt release:prerelease
 ```
 
 `prerelease` will just update the number after `MAJOR.MINOR.PATCH` (eg: `1.0.0-1`)
-If you want to add an alphanumeric identifier, you will need to add it by hand.
-Example: add `-alpha.0` to get something like `1.0.0-alpha.0`. Calling `grunt release:prerelease` will just update the last number to `1.0.0-alpha.1`.
+If you want to add an alphanumeric identifier, use the `preId` option.
+Example: add `preId: 'alpha'` to get something like `1.0.0-alpha.0`.
 
 **Releasing Unstable/Beta Versions**
 Sometimes it is useful to publish an 'unstable' or 'beta' version to `npm`, while leaving your last stable release as the default that gets installed on an `npm install`.
@@ -90,7 +90,7 @@ grunt release --npmtag canary
 NOTE: If the tag you pass is **true**, then the tag will be the *new* version number after the bump. Otherwise it will be the string you provided.
 
 
-**Bump multuple files at once**
+**Bump multiple files at once**
 
 Sometimes you may need to bump multiple files while releasing.
 
@@ -151,6 +151,7 @@ The following are all the release steps, you can disable any you need to:
       tagName: 'some-tag-<%= version %>', //default: '<%= version %>'
       commitMessage: 'check out my release <%= version %>', //default: 'release <%= version %>'
       tagMessage: 'tagging version <%= version %>', //default: 'Version <%= version %>',
+      preId: 'rc', // default: null
       github: {
         repo: 'geddski/grunt-release', //put your user/repo here
         usernameVar: 'GITHUB_USERNAME', //ENVIRONMENT VARIABLE that contains Github username

--- a/tasks/grunt-release.js
+++ b/tasks/grunt-release.js
@@ -21,7 +21,7 @@ module.exports = function(grunt){
       var files;
 
       if (options.bump) {
-        newVersion = semver.inc(pkg.version, type || 'patch');
+        newVersion = semver.inc(pkg.version, type || 'patch', options.preId);
       }
 
       // Check if options.additionalFiles is a single file
@@ -62,7 +62,8 @@ module.exports = function(grunt){
       push: true,
       pushTags: true,
       npm: true,
-      remote: 'origin'
+      remote: 'origin',
+      preId: null
     }, (grunt.config.data[this.name] || {}).options);
     var config = setup(options.file, type);
 


### PR DESCRIPTION
Addressing #101

Allow for a preId to be set, `semver.inc()` uses this to prefix a prerelease bump so that 1.0.0 becomes 1.0.0-alpha.0 for instance.