### PR TITLE
Github Enterprise Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ The following are all the release steps, you can disable any you need to:
       commitMessage: 'check out my release <%= version %>', //default: 'release <%= version %>'
       tagMessage: 'tagging version <%= version %>', //default: 'Version <%= version %>',
       github: {
+        apiRoot: 'http://git.example.com/v3', // Default: Github.com
         repo: 'geddski/grunt-release', //put your user/repo here
         usernameVar: 'GITHUB_USERNAME', //ENVIRONMENT VARIABLE that contains Github username
         passwordVar: 'GITHUB_PASSWORD' //ENVIRONMENT VARIABLE that contains Github password

--- a/tasks/grunt-release.js
+++ b/tasks/grunt-release.js
@@ -36,6 +36,10 @@ module.exports = function(grunt){
 
       options.additionalFiles.push(file);
 
+      if (typeof options.github !== 'undefined' && !options.github.apiRoot) {
+        options.github.apiRoot = 'https://api.github.com'; // Default Github.com api
+      }
+
       return {
         files: options.additionalFiles,
         newVersion: newVersion,
@@ -219,7 +223,7 @@ module.exports = function(grunt){
       }
 
       request
-        .post('https://api.github.com/repos/' + options.github.repo + '/releases')
+        .post(options.github.apiRoot + '/repos/' + options.github.repo + '/releases')
         .auth(process.env[options.github.usernameVar], process.env[options.github.passwordVar])
         .set('Accept', 'application/vnd.github.manifold-preview')
         .set('User-Agent', 'grunt-release')


### PR DESCRIPTION
Addressing #100

Setting `github: {apiRoot:''}` will allow you to use Github Enterprise. Not setting it will default to github.com.