### PR TITLE
Update before-/after*Tasks option names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,10 @@ The following are all the release steps, you can disable any you need to:
       tagName: 'some-tag-<%= version %>', //default: '<%= version %>'
       commitMessage: 'check out my release <%= version %>', //default: 'release <%= version %>'
       tagMessage: 'tagging version <%= version %>', //default: 'Version <%= version %>',
-      beforeBump: [], // optional grunt tasks to run before file versions are bumped
-      afterBump: [], // optional grunt tasks to run after file versions are bumped
-      beforeRelease: [], // optional grunt tasks to run after release version is bumped up but before release is packaged
-      afterRelease: [], // optional grunt tasks to run after release is packaged
+      beforeBumpTasks: [], // optional grunt tasks to run before file versions are bumped
+      afterBumpTasks: [], // optional grunt tasks to run after file versions are bumped
+      beforeReleaseTasks: [], // optional grunt tasks to run after release version is bumped up but before release is packaged
+      afterReleaseTasks: [], // optional grunt tasks to run after release is packaged
       github: {
         repo: 'geddski/grunt-release', //put your user/repo here
         usernameVar: 'GITHUB_USERNAME', //ENVIRONMENT VARIABLE that contains Github username


### PR DESCRIPTION
README suggest to use:
```js
      beforeBump: [], // optional grunt tasks to run before file versions are bumped
      afterBump: [], // optional grunt tasks to run after file versions are bumped
      beforeRelease: [], // optional grunt tasks to run after release version is bumped up but before release is packaged
      afterRelease: [], // optional grunt tasks to run after release is packaged
```
but the ones that does already work, are: `beforeBumpTasks`, `afterBumpTasks`, `beforeReleaseTasks`,  `afterReleaseTasks`