### PR TITLE
Fix github release response check + option to include release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ The following are all the release steps, you can disable any you need to:
         repo: 'geddski/grunt-release', //put your user/repo here
         usernameVar: 'GITHUB_USERNAME', //ENVIRONMENT VARIABLE that contains Github username
         passwordVar: 'GITHUB_PASSWORD' //ENVIRONMENT VARIABLE that contains Github password
+        releaseNotes: 'release_notes' //Folder containing release notes in .md format (v{version}.md) to be included in the release description
       }
     }
   }

--- a/tasks/grunt-release.js
+++ b/tasks/grunt-release.js
@@ -266,10 +266,10 @@ module.exports = function(grunt){
           body: releaseNotes
         })
         .end(function(res){
-          if (res.statusCode === 201){
-            success();
-          } else {
+          if (res && res.statusCode !== 201){
             deferred.reject('Error creating github release. Response: ' + res.text);
+          } else {
+            success();
           }
         });
 

--- a/tasks/grunt-release.js
+++ b/tasks/grunt-release.js
@@ -265,11 +265,11 @@ module.exports = function(grunt){
           prerelease: type === 'prerelease',
           body: releaseNotes
         })
-        .end(function(res){
-          if (res && res.statusCode !== 201){
-            deferred.reject('Error creating github release. Response: ' + res.text);
-          } else {
+        .end(function(err, res){
+          if (res && res.statusCode === 201){
             success();
+          } else {
+            deferred.reject('Error creating github release. Response: ' + res.text);
           }
         });
 

--- a/tasks/grunt-release.js
+++ b/tasks/grunt-release.js
@@ -234,6 +234,11 @@ module.exports = function(grunt){
 
     function githubRelease(){
       var deferred = Q.defer();
+      var releaseNotes;
+
+      if(options.github.releaseNotes) {
+        releaseNotes = grunt.file.read(options.github.releaseNotes + '/v' + config.newVersion + '.md');
+      }
 
       function success(){
         grunt.log.ok('created ' + tagName + ' release on github.');
@@ -257,7 +262,8 @@ module.exports = function(grunt){
         .send({
           'tag_name': tagName,
           name: tagMessage,
-          prerelease: type === 'prerelease'
+          prerelease: type === 'prerelease',
+          body: releaseNotes
         })
         .end(function(res){
           if (res.statusCode === 201){


### PR DESCRIPTION
Lib superagent was updated in npm, causing the callback function in end to match the following signature:
  .end(function(err, res){
where grunt-release was expecting
  .end(function(res){


Added the option to include a folder containing release notes (v{version}.md) to allow for more sophisticated release description in github.