### PR TITLE
Added the ability to include release notes in github releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ The following are all the release steps, you can disable any you need to:
         repo: 'geddski/grunt-release', //put your user/repo here
         usernameVar: 'GITHUB_USERNAME', //ENVIRONMENT VARIABLE that contains Github username
         passwordVar: 'GITHUB_PASSWORD' //ENVIRONMENT VARIABLE that contains Github password
+        releaseNotes: 'release_notes' //Folder containing release notes in .md format (v{version}.md) to be included in the release description
       }
     }
   }

--- a/tasks/grunt-release.js
+++ b/tasks/grunt-release.js
@@ -234,6 +234,11 @@ module.exports = function(grunt){
 
     function githubRelease(){
       var deferred = Q.defer();
+      var releaseNotes;
+
+      if(options.github.releaseNotes) {
+        releaseNotes = grunt.file.read(options.github.releaseNotes + '/v' + config.newVersion + '.md');
+      }
 
       function success(){
         grunt.log.ok('created ' + tagName + ' release on github.');
@@ -257,7 +262,8 @@ module.exports = function(grunt){
         .send({
           'tag_name': tagName,
           name: tagMessage,
-          prerelease: type === 'prerelease'
+          prerelease: type === 'prerelease',
+          body: releaseNotes
         })
         .end(function(res){
           if (res.statusCode === 201){


### PR DESCRIPTION
Specify a folder in the github config and grunt-release will automatically send matching (v{version}.md) file from the folder as the description in the github release.
