### PR TITLE
Show help text about semver with grunt release:help

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,12 @@ grunt.loadNpmTasks('grunt-release');
 ```
 
 ## Using grunt-release
+Version numbers should always be bumped in accordance to
+[semver](http://semver.org/). If you ever forget which part of the version
+number should be changed, you can run `grunt release:help` for a quick summary.
 
 **Patch Release:**
+Patch releases are done when making backwards-compatible bug fixes.
 ```shell
 grunt release
 ```
@@ -51,11 +55,14 @@ grunt release:patch
 ```
 
 **Minor Release:**
+If you've added functionality in a backwards-compatible manner, a minor release
+is the right thing to do.
 ```shell
 grunt release:minor
 ```
 
 **Major Release:**
+Should you have made incompatible API changes, it's time for a major release.
 ```shell
 grunt release:major
 ```

--- a/tasks/grunt-release.js
+++ b/tasks/grunt-release.js
@@ -14,6 +14,21 @@ var Q = require('q');
 
 module.exports = function(grunt){
   grunt.registerTask('release', 'Bump version, git tag, git push, npm publish', function(type){
+    function help(type) {
+      var helpText = {
+        major: 'Release a MAJOR version when you make incompatible API changes.',
+        minor: 'Release a MINOR version when you add functionality in a backwards-compatible manner.',
+        patch: 'Release a PATCH version when you make backwards-compatible bug fixes.'
+      };
+
+      if (type in helpText) {
+        grunt.log.ok(helpText[type]);
+      } else {
+        for (type in helpText) {
+          grunt.log.ok(helpText[type]);
+        }
+      }
+    }
 
     function setup(file, type){
       var pkg = grunt.file.readJSON(file);
@@ -58,6 +73,11 @@ module.exports = function(grunt){
         newVersion: newVersion,
         pkg: pkg
       };
+    }
+
+    if (type === 'help') {
+      help();
+      return;
     }
 
     // Defaults
@@ -310,6 +330,9 @@ module.exports = function(grunt){
 
       return fn;
     }
+
+    // Show help for the current release type
+    help(type || 'patch');
 
     new Q()
       .then(ifEnabled('beforeBump', runTasks('beforeBump')))


### PR DESCRIPTION
I'm sometimes unsure when to do a major/minor/patch release. It would be nice to add a simple task release:help that shows the semver intro:

```
    MAJOR version when you make incompatible API changes,
    MINOR version when you add functionality in a backwards-compatible manner, and
    PATCH version when you make backwards-compatible bug fixes.
```