### PR TITLE
Fix grunt task run fail handling

### DIFF
--- a/tasks/grunt-release.js
+++ b/tasks/grunt-release.js
@@ -305,21 +305,18 @@ module.exports = function(grunt) {
 
         function runTasks(taskName) {
             var tasks = options[taskName];
+            var promises = [];
 
-            var fn = function() {
-                return Q.fcall(function() {
-                    if (tasks.length) {
-                        grunt.log.ok('running ' + taskName + ' ');
-                        if (!nowrite) {
-                            for (var i = 0; i < tasks.length; i++) {
-                                run('grunt ' + tasks[i], '-> ' + tasks[i]);
-                            }
-                        }
+            if (Array.isArray(tasks) && tasks.length) {
+                grunt.log.ok('running ' + taskName + ' ');
+                if (!nowrite) {
+                    for (var i = 0; i < tasks.length; i++) {
+                        promises.push(run('grunt ' + tasks[i], '-> ' + tasks[i]));
                     }
-                });
-            };
+                }
+            }
 
-            return fn;
+            return Q.all(promises);
         }
 
         new Q()


### PR DESCRIPTION
Hello,   
I want to report an issue and request a merge for it's fix as well.

When using `afterBump` or any option which runs grunt tasks it will be always successful and doesn't respect the return status of the called tasks.

### Steps to reproduces:
- Create this GruntFile.js
```javascript
module.exports = function (grunt) {
	// create some task for test
	grunt.registerTask('yes', 'always successful task', function () {
		console.log('yes called');
		return true;
	});

	grunt.registerTask('no', 'never successful task', function () {
		console.log('no called');
		return false;
	});

	// setup grunt-release
	grunt.config('release', {
		options: {
			bump: true,
			afterBump: [
				'yes',
				'no',
				'yes'
			],
			file: 'package.json',
			add: true,
			commit: true,

			// we don't need these for the experiment
			push: false,
			tag: false,
			pushTags: false,
			npm: false,
			npmtag: false
		}
	});

	grunt.loadNpmTasks('grunt-release');
};
```

- (optional) modify the `afterBump` with different `yes` and `no` order or quantity.
 
- Run `grunt release`

### Expected results:
The task should fail and exit after one `no` task executed.

### Actual result:
The `grunt-release` task will create the commit after the `no` task fails.

### How to fix
The issues is in the [`runTask`](https://github.com/geddski/grunt-release/blob/master/tasks/grunt-release.js#L306) method. The `Q.fcall` will always resolve the promise because the function doesn't have return value. In my changeset I simplified the method and now it returns all the executed tasks in a `Q.all` call.

This merge request will fix the issue.   
Please review and merge it accordingly!