### PR TITLE
Allow tasks to preserve the original flags

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -47,7 +47,8 @@ module.exports = function(grunt) {
           changelog: 'test/fixtures/_CHANGELOG.md',
           additionalFiles: ['test/fixtures/_bower.json'],
           changelogText: '### <%= version %>\n',
-          commitMessage: 'v<%= version %>'
+          commitMessage: 'v<%= version %>',
+          beforeRelease: ['dummyBefore', { name: 'dummyBefore', preserveFlags: true }]
         }
       },
       absolute: {
@@ -114,6 +115,18 @@ module.exports = function(grunt) {
     'nodeunit',
     'clean'
   ]);
+  
+  grunt.registerTask('dummyBefore', function(){
+    var flags = grunt.option.flags().join(' ');
+    var filePath = 'test/fixtures/_dummyBefore.json';
+    var contents = grunt.file.exists(filePath) ? grunt.file.readJSON(filePath) : { timesCalled: 0, flags: [] };
+    var updatedObject = {
+      timesCalled: contents.timesCalled+1,
+      flags: flags.length ? contents.flags.concat(flags) : contents.flags
+    };
+    
+    grunt.file.write(filePath, JSON.stringify(updatedObject));
+  });
 
   grunt.registerMultiTask('setup', 'Setup test fixtures', function(){
     this.files.forEach(function(f){
@@ -124,6 +137,7 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('releaseTest', function(){
     var args = (this.data.args || []).join(':');
 
+    grunt.option.init({ flag: 'test' });
     grunt.config.set('release', {});
     grunt.config.merge({
       release: grunt.config.data[this.name]

--- a/README.md
+++ b/README.md
@@ -176,6 +176,26 @@ The following are all the release steps, you can disable any you need to:
 
 If you want to use multiline commit messages just pass an array to the `commitMessage` option instead of a string.
 
+### Notes on queued tasks
+By default, the queued tasks ran through the `beforeBump`, `afterBump`, `beforeRelease`, `afterRelease` options will *not* inherit the flags specified when the `release` task is ran. To preserve those flags, you can optionally pass an object to those arrays in the following format:
+
+```js
+{
+   name: 'taskName',
+   preserveFlags: true // defaults to false
+}
+```
+
+You can still pass only strings to that array, or mix the two as need be. For example:
+
+```js
+  release: {
+    options: {
+      beforeRelease: ['oneTask', { name: 'anotherTask', preserveFlags: true }]
+    }
+  }
+```
+
 ### Notes on GitHub Releases:
 
 1. Yes, you have to use environment variables.

--- a/tasks/grunt-release.js
+++ b/tasks/grunt-release.js
@@ -305,14 +305,27 @@ module.exports = function(grunt) {
 
         function runTasks(taskName) {
             var tasks = options[taskName];
+            var flags = grunt.option.flags().join(' ');
+            var msg;
 
             var fn = function() {
                 return Q.fcall(function() {
                     if (tasks.length) {
                         grunt.log.ok('running ' + taskName + ' ');
+
+                        if(flags.length) {
+                          grunt.log.ok('-> current flags: ' + flags);
+                        }
+
                         if (!nowrite) {
                             for (var i = 0; i < tasks.length; i++) {
-                                run('grunt ' + tasks[i], '-> ' + tasks[i]);
+                                if(typeof tasks[i] === 'string' || !tasks[i].preserveFlags){
+                                    msg = '-> ' + tasks[i] + (flags.length ? ' (ignoring current flags)' : '');
+                                    run('grunt ' + tasks[i], msg);
+                                }
+                                else if (tasks[i].preserveFlags){
+                                    run('grunt ' + tasks[i].name + ' ' + flags, '-> ' + tasks[i].name + ' ' + flags);
+                                }
                             }
                         }
                     }

--- a/test/release_test.js
+++ b/test/release_test.js
@@ -30,5 +30,13 @@ exports.release = {
   },
   bumpMajor: function(test){
     compareFiles(test, 'component-major.json', 'should bump major version');
+  },
+  preserveFlags: function(test){
+    var beforeTask = grunt.file.readJSON('test/fixtures/_dummyBefore.json');
+    
+    test.equal(beforeTask.timesCalled, 2);
+    test.equal(beforeTask.flags.length, 1);
+    test.equal(beforeTask.flags[0], '--flag=test');
+    test.done();
   }
 };


### PR DESCRIPTION
Tasks that would be queued using the `beforeBump`, `afterBump`, `beforeRelease` and `afterRelease` options would not inherit the flags ran through the CLI command, as reported by @renemeye in #147.

I don't know whether it was the intended behaviour or not, but I find it very limiting, so I implemented an optional feature to allow flag inheritance.

The implementation is backwards-compatible, as nothing changes if you pass an array of task names strings to the queue. However, you have the option to pass an object in this fashion:

```js
release: {
    options: {
      beforeRelease: ['oneTask', { name: 'anotherTask', preserveFlags: true }]
    }
}
```

When done this way, the flags will be correctly inherited by the task named `anotherTask`.

I have also included the tests for this feature, although tests for those queued tasks were not present: in this case I barely added the tests for my feature, checking whether the task is ran with or without the flags, I don't check the orders, but maybe we should consider adding tests for those features as well.

Let me know what you think about this.